### PR TITLE
Bump version to 1.16.2 (#14)

### DIFF
--- a/common/rootfs/etc/cont-init.d/zigbee2mqtt.sh
+++ b/common/rootfs/etc/cont-init.d/zigbee2mqtt.sh
@@ -60,6 +60,8 @@ fi
 CONFIG_PATH=/data/options.json
 bashio::log.info "Adjusting Zigbee2mqtt core yaml config with add-on quirks ..."
 cat "$CONFIG_PATH" | jq 'del(.data_path, .zigbee_shepherd_devices, .socat)' \
+    | jq 'if .devices then .devices = (.devices | split(",")|map(gsub("\\s+";"";"g"))) else . end' \
+    | jq 'if .groups then .groups = (.groups | split(",")|map(gsub("\\s+";"";"g"))) else . end' \
     | jq 'if .advanced.ext_pan_id_string then .advanced.ext_pan_id = (.advanced.ext_pan_id_string | (split(",")|map(tonumber))) | del(.advanced.ext_pan_id_string) else . end' \
     | jq 'if .advanced.network_key_string then .advanced.network_key = (.advanced.network_key_string | (split(",")|map(tonumber))) | del(.advanced.network_key_string) else . end' \
     | jq 'if .device_options_string then .device_options = (.device_options_string|fromjson) | del(.device_options_string) else . end' \

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -91,7 +91,8 @@
       "keepalive": "int?",
       "version": "int?",
       "reject_unauthorized": "bool?",
-      "include_device_information": "bool?"
+      "include_device_information": "bool?",
+      "force_disable_retain": "bool?"
     },
     "serial": {
       "port": "str",
@@ -154,6 +155,7 @@
       "new_api": "bool?"
     },
     "frontend": {
+      "host": "str?",
       "port": "int?"
     },
     "socat": {

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.16.2
+- Updated Zigbee2mqtt to version [`1.16.2`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.16.2)
+- New configuration options
+    - `mqtt`
+        - `force_disable_retain`
+    - `frontend`
+        - `host`
+- `devices` and `groups` options now accept a comma-separated string of files
+
 ## 1.16.1-1
 - Allow add-on to start with other mqtt servers not just built in
 

--- a/zigbee2mqtt/DOCS.md
+++ b/zigbee2mqtt/DOCS.md
@@ -70,6 +70,7 @@ When set, the add-on will scan your `data_path` for a `devices.js` file, and wil
 - Depending on your configuration, the MQTT server config may need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Home Assistant's Mosquitto add-on.
 - To find out which serial ports you have exposed go to **Supervisor → System → Host system → ⋮ → Hardware**
 - Please see this add-on's [documentation on GitHub](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/blob/dev/zigbee2mqtt/DOCS.md#socat) for further add-on-specific information (using Socat, how to add support for new devices etc.).
+- The 'devices' and 'groups' configuration options accept arrays of files since Zigbee2MQTT v1.16.2. In order to maintain backwards compatibility of configurations, the same functionality is achieved in this addon by the use of comma-separated strings.
 
 # Additional Configuration Options
 - `network_key_string`  

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.16.1-1",
+  "version": "1.16.2",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "auto_uart": true,
@@ -91,7 +91,8 @@
       "keepalive": "int?",
       "version": "int?",
       "reject_unauthorized": "bool?",
-      "include_device_information": "bool?"
+      "include_device_information": "bool?",
+      "force_disable_retain": "bool?"
     },
     "serial": {
       "port": "str",
@@ -154,6 +155,7 @@
       "new_api": "bool?"
     },
     "frontend": {
+      "host": "str?",
       "port": "int?"
     },
     "socat": {


### PR DESCRIPTION
* Bump version to 1.16.2

* Fix type in schema

<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist

- [x] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [x] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [x] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options
