### PR TITLE
Fix ignored "log_output" option

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -44,6 +44,7 @@
     },
     "advanced": {
       "log_level": "info",
+      "log_output": ["console", "file"],
       "pan_id": 6754,
       "channel": 11,
       "network_key": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
@@ -114,6 +115,9 @@
       "log_directory": "str?",
       "log_file": "str?",
       "log_rotation": "bool?",
+      "log_output": [
+        "str?"
+      ],
       "timestamp_format": "str?",
       "baudrate": "int?",
       "rtscts": "bool?",

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -3,6 +3,14 @@
   - `log_output` now required option in `advanced`
 - Fix `log_output` option being ignored
 
+Default zigbee2mqtt options for `log_output`
+```
+advanced:
+  log_output: 
+     - console
+     - file
+```
+
 ## 1.18.1-1
 - Updated Zigbee2mqtt to version [`1.18.1`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.18.1)
 - Fix OTA configuration required when starting

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.18.1-2
+- ⚠️ **Breaking changes**
+  - `log_output` now required option in `advanced`
+- Fix `log_output` option being ignored
+
 ## 1.18.1-1
 - Updated Zigbee2mqtt to version [`1.18.1`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.18.1)
 - Fix OTA configuration required when starting

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,15 +1,7 @@
-## 1.18.1-2
-- ⚠️ **Breaking changes**
-  - `log_output` now required option in `advanced`
+## 1.18.1-3
+- ⚠️ **Breaking change**
+  - `log_output` now required option in `advanced`. [Zigbee2mqtt configuration](https://www.zigbee2mqtt.io/information/configuration.html) for possible `log_output` options
 - Fix `log_output` option being ignored
-
-Default zigbee2mqtt options for `log_output`
-```
-advanced:
-  log_output: 
-     - console
-     - file
-```
 
 ## 1.18.1-1
 - Updated Zigbee2mqtt to version [`1.18.1`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.18.1)

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.18.1-1",
+  "version": "1.18.1-2",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "uart": true,

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -44,6 +44,7 @@
     },
     "advanced": {
       "log_level": "warn",
+      "log_output": ["console", "file"],
       "pan_id": 6754,
       "channel": 11,
       "network_key": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
@@ -114,6 +115,9 @@
       "log_directory": "str?",
       "log_file": "str?",
       "log_rotation": "bool?",
+      "log_output": [
+        "str?"
+      ],
       "timestamp_format": "str?",
       "baudrate": "int?",
       "rtscts": "bool?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.18.1-2",
+  "version": "1.18.1-3",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "uart": true,


### PR DESCRIPTION
Added a fix for the issue where ```log_output``` was being ignored and not populated into configurations.yaml.

#### Checklist
- [x] PR done against `dev` branch
- [x] Updated `common/Dockerfile` with new version
- [x] Updated `zigbee2mqtt/CHANGELOG.md` file with new changes
- [x] Updated `zigbee2mqtt/DOCS.md` with any changes
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
