### PR TITLE
add humidity precision to device options

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -143,6 +143,7 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.18.1-3
+- Added support for `humidity_precision` option under `device_options`
+
 ## 1.18.1-2
 - Added missing ezsp agapter type for serial
 

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -143,6 +143,7 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.18.2-1",
+  "version": "1.18.2-2",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "uart": true,


### PR DESCRIPTION
Currently to add `humidity_precision` as a `device_options`, it's necessary to use `device_options_str`. While that works well, it's quite cumbersome for beginning users (e.g. it overwrites anything else set in `device_options`...).

I propose to add the quite common `humidity_precision` as an additional supported field in `device_options`.

**Checklist**

- [x] PR done against dev branch
- [x] Updated common/Dockerfile with new version
- [x] Updated zigbee2mqtt/CHANGELOG.md file with new changes
- [ ] Updated zigbee2mqtt/DOCS.md with any changes (Not Applicable)
- [x] Add any new configuration options to zigbee2mqtt/config.json and zigbee2mqtt-edge/config.json.