### PR TITLE
Add `advanced.log_output` option to config

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -113,6 +113,7 @@
       "log_level": "match(^info|debug|warn|error$)?",
       "log_directory": "str?",
       "log_file": "str?",
+      "log_output": ["list(console|file|syslog)?"],
       "log_rotation": "bool?",
       "timestamp_format": "str?",
       "baudrate": "int?",

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.22.0-1
+## 1.21.0-2
 - Added `advanced.log_output` config option
 
 ## 1.21.0-1

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.18.1-3
+- Added `advanced.log_output` config option
+
 ## 1.18.1-2
 - Added missing ezsp agapter type for serial
 

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -113,6 +113,7 @@
       "log_level": "match(^info|debug|warn|error$)?",
       "log_directory": "str?",
       "log_file": "str?",
+      "log_output": ["list(console|file|syslog)?"],
       "log_rotation": "bool?",
       "timestamp_format": "str?",
       "baudrate": "int?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.21.0-1",
+  "version": "1.21.0-2",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "uart": true,


### PR DESCRIPTION
The [Z2M configuration](https://www.zigbee2mqtt.io/information/configuration.html) includes an option to set where the log is output in `advanced.log_output`. It defaults to `file` and `console` but you can adjust it to specify where logging goes or suppress logging entirely. This makes that option available.

<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist
- [x] PR done against `dev` branch
- [ ] Updated `common/Dockerfile` with new version
- [x] Updated `zigbee2mqtt/CHANGELOG.md` file with new changes
- [ ] Updated `zigbee2mqtt/DOCS.md` with any changes
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
