### PR TITLE
Add support for humidity_precision option

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -144,6 +144,7 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.21.0-2
+- Added support for `humidity_precision` option under `device_options`
+
 ## 1.21.0-1
 - Updated Zigbee2MQTT to version [`1.21.0`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.21.0)
 

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.21.0-1
+- Updated Zigbee2MQTT to version [`1.21.0`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.21.0)
+
 ## 1.20.0-1
 - Updated Zigbee2MQTT to version [`1.20.0`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.20.0)
 

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -143,6 +143,7 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.20.0-1",
+  "version": "1.21.0-1",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2mqtt add-on",
   "uart": true,


### PR DESCRIPTION
Previous [PR](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pull/66) against dev got closed due to dev being deleted.

This is a minimal refresh PR, no version bumps. I'll update it to point to dev once it's recreated.

--

Currently to add `humidity_precision` as a `device_options`, it's necessary to use `device_options_str`. While that works well, it's quite cumbersome for beginning users (e.g. it overwrites anything else set in `device_options`...).

I propose to add the quite common `humidity_precision` as an additional supported field in `device_options`.