### PR TITLE
Removed new_api option as it's now default

### DIFF
--- a/zigbee2mqtt/DOCS.md
+++ b/zigbee2mqtt/DOCS.md
@@ -2,13 +2,11 @@
 By default the add-on has `permit_join` set to `false`. To allow devices to join you need to activate this after the add-on has started. You can now use the [built-in frontend](https://www.zigbee2mqtt.io/information/frontend.html) to achieve this. For details on how to enable the built-in frontent see the next section.
 
 # Enabling the built-in Frontend
-Make sure your add-on options have the right settings. If you already had experimental options, you might now automatically get `new_api` set properly on update.
+Make sure your add-on options have the right settings.
 
 ```yaml
 frontend:
   port: 8099
-experimental:
-  new_api: true
 ```
 
 Enable `ingress` to have the frontend available in your UI: **Supervisor → Dashboard → Zigbee2mqtt → Show in sidebar**. You can find more details about the feature on the [Zigbee2mqtt documentation](https://www.zigbee2mqtt.io/information/frontend.html).


### PR DESCRIPTION
Because:
https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/blob/b870fd2c0b92ee4944659c403fc0bf739fbdd6af/zigbee2mqtt/CHANGELOG.md#1171-1
Removed new_api option as it's now default