### PR TITLE
Remove Z2M configuration from addon (#270)

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -6,7 +6,9 @@ ARG BUILD_VERSION
 
 RUN apk add --no-cache --virtual .build-dependencies \
     make gcc g++ linux-headers udev git python2 && \
-    apk add --no-cache jq nodejs npm socat
+    apk add --no-cache nodejs npm socat
+
+RUN [ "${BUILD_VERSION}" = "edge" ] || apk add --no-cache jq
 
 RUN if [ "${BUILD_VERSION}" = "edge" ]; \
     then \
@@ -39,3 +41,12 @@ RUN cd /app && \
     rm -rf /root/.cache /root/.npm
 
 COPY rootfs /
+
+RUN if [ "${BUILD_VERSION}" = "edge" ]; \
+    then \
+        mv /etc/cont-init.d/zigbee2mqtt-edge.sh /etc/cont-init.d/zigbee2mqtt.sh && \
+        mv /etc/services.d/zigbee2mqtt/run-edge /etc/services.d/zigbee2mqtt/run; \
+    else \
+        rm /etc/cont-init.d/zigbee2mqtt-edge.sh && \
+        rm /etc/services.d/zigbee2mqtt/run-edge; \
+    fi

--- a/common/rootfs/etc/cont-init.d/zigbee2mqtt-edge.sh
+++ b/common/rootfs/etc/cont-init.d/zigbee2mqtt-edge.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/with-contenv bashio
+DATA_PATH=$(bashio::config 'data_path')
+
+if bashio::config.true 'zigbee_shepherd_devices'; then
+    bashio::log.debug "Searching for custom devices.js file in zigbee2mqtt data path..."
+    if bashio::fs.file_exists "$DATA_PATH/devices.js"; then
+        bashio::log.info "File devices.js found, copying to ./node_modules/zigbee-herdsman-converters/"
+        cp -f "$DATA_PATH"/devices.js ./node_modules/zigbee-herdsman-converters/devices.js
+    else
+        bashio::log.warning "No devices.js file found in data path, starting with default devices.js"
+    fi
+else
+    bashio::log.debug "No devices.js file manipulation required"
+fi
+
+if ! bashio::fs.file_exists "$DATA_PATH/configuration.yaml"; then
+    mkdir -p "$DATA_PATH" || bashio::exit.nok "Could not create $DATA_PATH"
+
+    cat <<EOF > "$DATA_PATH/configuration.yaml"
+homeassistant: true
+EOF
+fi

--- a/common/rootfs/etc/services.d/zigbee2mqtt/run-edge
+++ b/common/rootfs/etc/services.d/zigbee2mqtt/run-edge
@@ -1,0 +1,40 @@
+#!/usr/bin/with-contenv bashio
+
+if bashio::config.true 'zigbee_herdsman_debug'; then
+    bashio::log.info "Zigbee Herdsman debug logging enabled"
+    export DEBUG="zigbee-herdsman:*"
+fi
+export NODE_PATH=/app/node_modules
+export ZIGBEE2MQTT_DATA="$(bashio::config 'data_path')"
+export ZIGBEE2MQTT_CONFIG_FRONTEND='{"port": 8099}'
+
+# Expose addon configuration through environment variables.
+function export_config() {
+    local key=${1}
+    local subkey
+
+    if bashio::config.is_empty "${key}"; then
+        return
+    fi
+
+    for subkey in $(bashio::jq "$(bashio::config "${key}")" 'keys[]'); do
+        export "ZIGBEE2MQTT_CONFIG_$(bashio::string.upper "${key}")_$(bashio::string.upper "${subkey}")=$(bashio::config "${key}.${subkey}")"
+    done
+}
+
+export_config 'mqtt'
+export_config 'serial'
+
+if bashio::config.is_empty 'mqtt' && bashio::var.has_value "$(bashio::services 'mqtt')"; then
+    if bashio::var.true "$(bashio::services 'mqtt' 'ssl')"; then
+        export ZIGBEE2MQTT_CONFIG_MQTT_SERVER="mqtts://$(bashio::services 'mqtt' 'host'):$(bashio::services 'mqtt' 'port')"
+    else
+        export ZIGBEE2MQTT_CONFIG_MQTT_SERVER="mqtt://$(bashio::services 'mqtt' 'host'):$(bashio::services 'mqtt' 'port')"
+    fi
+    export ZIGBEE2MQTT_CONFIG_MQTT_USER="$(bashio::services 'mqtt' 'username')"
+    export ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD="$(bashio::services 'mqtt' 'password')"
+fi
+
+cd /app || bashio::exit.nok "Could not change directory to /app"
+bashio::log.info "Handing over control to Zigbee2mqtt Core ..."
+exec npm start

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -31,145 +31,40 @@
   },
   "options": {
     "data_path": "/config/zigbee2mqtt",
-    "external_converters": [],
-    "devices": "devices.yaml",
-    "groups": "groups.yaml",
-    "homeassistant": true,
-    "permit_join": false,
-    "mqtt": {
-      "base_topic": "zigbee2mqtt"
-    },
-    "serial": {
-      "port": "/dev/ttyACM0"
-    },
-    "advanced": {
-      "log_level": "info",
-      "pan_id": 6754,
-      "channel": 11,
-      "network_key": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
-      "availability_blocklist": [],
-      "availability_passlist": []
-    },
-    "device_options": {},
-    "blocklist": [],
-    "passlist": [],
-    "queue": {},
-    "frontend": {
-      "port": 8099
-    },
-    "experimental": {},
-    "availability": false,
     "socat": {
       "enabled": false,
       "master": "pty,raw,echo=0,link=/tmp/ttyZ2M,mode=777",
       "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5",
       "options": "-d -d",
       "log": false
-    }
+    },
+    "mqtt": {},
+    "serial": {}
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
     "zigbee_herdsman_debug": "bool?",
-    "external_converters": [
-      "str?"
-    ],
     "data_path": "str",
-    "devices": "str?",
-    "groups": "str?",
-    "homeassistant": "bool",
-    "permit_join": "bool",
-    "mqtt": {
-      "base_topic": "str",
-      "server": "str?",
-      "ca": "str?",
-      "key": "str?",
-      "cert": "str?",
-      "user": "str?",
-      "password": "str?",
-      "client_id": "str?",
-      "keepalive": "int?",
-      "version": "int?",
-      "reject_unauthorized": "bool?",
-      "include_device_information": "bool?",
-      "force_disable_retain": "bool?"
-    },
-    "serial": {
-      "port": "str",
-      "disable_led": "bool?",
-      "adapter": "match(zstack|deconz|zigate|ezsp)?"
-    },
-    "blocklist": [
-      "str?"
-    ],
-    "passlist": [
-      "str?"
-    ],
-    "advanced": {
-      "pan_id": "int(0,65536)?",
-      "ext_pan_id_string": "match(^(\\s*\\d+\\s*,){7}(\\s*\\d+\\s*)$)?",
-      "channel": "int(11,26)?",
-      "cache_state": "bool?",
-      "cache_state_persistent": "bool?",
-      "cache_state_send_on_startup": "bool?",
-      "log_level": "match(^info|debug|warn|error$)?",
-      "log_directory": "str?",
-      "log_file": "str?",
-      "log_output": ["list(console|file|syslog)?"],
-      "log_rotation": "bool?",
-      "timestamp_format": "str?",
-      "baudrate": "int?",
-      "rtscts": "bool?",
-      "soft_reset_timeout": "int?",
-      "adapter_concurrent": "int?",
-      "adapter_delay": "int?",
-      "network_key": [
-        "int?"
-      ],
-      "network_key_string": "match(^(\\s*\\d+\\s*,){15}(\\s*\\d+\\s*)$)?",
-      "last_seen": "match(^disable|ISO_8601|epoch)?",
-      "elapsed": "bool?",
-      "availability_timeout": "int?",
-      "availability_blocklist": [
-        "str?"
-      ],
-      "availability_passlist": [
-        "str?"
-      ],
-      "report": "bool?",
-      "homeassistant_discovery_topic": "str?",
-      "homeassistant_status_topic": "str?",
-      "homeassistant_legacy_triggers": "bool?",
-      "homeassistant_legacy_entity_attributes": "bool?",
-      "ikea_ota_use_test_url": "bool?",
-      "legacy_api": "bool?"
-    },
-    "device_options": {
-      "occupancy_timeout": "int?",
-      "temperature_precision": "int?",
-      "humidity_precision": "int?",
-      "legacy": "bool?",
-      "retain": "bool?"
-    },
-    "device_options_string": "str?",
-    "queue": {
-      "delay": "int?",
-      "simultaneously": "int?"
-    },
-    "experimental": {
-      "transmit_power": "int?",
-      "output": "str?"
-    },
-    "availability": "bool?",
-    "frontend": {
-      "host": "str?",
-      "port": "int?"
-    },
     "socat": {
       "enabled": "bool?",
       "master": "str?",
       "slave": "str?",
       "options": "str?",
       "log": "bool?"
+    },
+    "mqtt": {
+      "server": "str?",
+      "ca": "str?",
+      "key": "str?",
+      "cert": "str?",
+      "user": "str?",
+      "password": "str?"
+    },
+    "serial": {
+      "port": "str?",
+      "adapter": "match(zstack|deconz|zigate|ezsp)?",
+      "baudrate": "int?",
+      "rtscts": "bool?"
     }
   },
   "image": "zigbee2mqtt/zigbee2mqtt-edge-{arch}"


### PR DESCRIPTION
* Remove Z2M configuration from addon

Fixes #41. Fixes #77. Fixes #109.

* Revert changes to stable

* Fix `frontend` config

* Add back `mqtt` and `serial`

<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist
- [ ] PR done against `dev` branch
- [ ] Updated `zigbee2mqtt/config.json` with new version
- [ ] Updated `zigbee2mqtt/CHANGELOG.md` file with new changes
- [ ] Updated `zigbee2mqtt/DOCS.md` with any changes
- [ ] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
