### PR TITLE
Update config.json

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -1,6 +1,7 @@
 {
   "name": "Zigbee2MQTT Edge",
   "version": "edge",
+  "Init": true,
   "slug": "zigbee2mqtt_edge",
   "description": "Development build of the Zigbee2MQTT add-on",
   "uart": true,


### PR DESCRIPTION
fix error on startup "fatal: can only run as pid 1 "
S6-Overlay 3.x update on our docker base images

https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/