### PR TITLE
Finish script to call halt or restart

### DIFF
--- a/common/rootfs/etc/s6-overlay/s6-rc.d/z2m/finish
+++ b/common/rootfs/etc/s6-overlay/s6-rc.d/z2m/finish
@@ -1,0 +1,16 @@
+
+#!/usr/bin/env bashio
+# ==============================================================================
+# Take down the S6 supervision tree when example fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
+
+declare APP_EXIT_CODE=${1}
+
+if [[ "${APP_EXIT_CODE}" -ne 0 ]] && [[ "${APP_EXIT_CODE}" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
+  echo "${APP_EXIT_CODE}" > /run/s6-linux-init-container-results/exitcode
+  exec /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "Service restart after closing"

--- a/common/rootfs/etc/s6-overlay/s6-rc.d/z2m/finish
+++ b/common/rootfs/etc/s6-overlay/s6-rc.d/z2m/finish
@@ -1,7 +1,7 @@
 
 #!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when example fails
+# Take down the S6 supervision tree when z2m fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
 


### PR DESCRIPTION
Looks like we still need a finish script here: https://github.com/home-assistant/supervisor/issues/3884#issuecomment-1254364782

This is a straight copy from addons example:
https://github.com/home-assistant/addons-example/blob/6d5f17959c0eb8d3d0c2e3deaea9cde7f0fa09b7/example/rootfs/etc/services.d/example/finish#L1-L15

It should work but feel free to customize to the needs of Z2M. `bashio::exit.nok` exits with [exit code 1](https://github.com/hassio-addons/bashio/blob/f8fc8555b9f177c1de0a036c5fcaeede8c544ba8/lib/const.sh#L22) so to have that properly exit the addon this needs to call `halt` when that exit code is received. Other then that its entirely up to how Z2M works and what exit codes should restart it or not.