### PR TITLE
Update documentation how to activate the Frontend sidebar item

### DIFF
--- a/zigbee2mqtt/DOCS.md
+++ b/zigbee2mqtt/DOCS.md
@@ -2,7 +2,7 @@
 By default the add-on has `permit_join` set to `false`. To allow devices to join you need to activate this after the add-on has started. You can now use the [built-in frontend](https://www.zigbee2mqtt.io/information/frontend.html) to achieve this. For details on how to enable the built-in frontent see the next section.
 
 # Enabling the built-in frontend
-Enable `ingress` to have the frontend available in your UI: **Supervisor → Dashboard → Zigbee2MQTT → Show in sidebar**. You can find more details about the feature on the [Zigbee2MQTT documentation](https://www.zigbee2mqtt.io/information/frontend.html).
+Enable `ingress` to have the frontend available in your UI: **Settings → Add-ons → Zigbee2MQTT → Show in sidebar**. You can find more details about the feature on the [Zigbee2MQTT documentation](https://www.zigbee2mqtt.io/information/frontend.html).
 
 # Configuration
 Configuration required to startup Zigbee2MQTT is available from the addon configuration. The rest of the options can be configured via the Zigbee2MQTT frontend.


### PR DESCRIPTION
Home Assistant's settings were reorganized in 2022.5, see [1]. Fix the documentation for activating the Zigbee2MQTT Frontend sidebar item.

[1]: https://www.home-assistant.io/blog/2022/05/04/release-20225/#reorganized-settings-menu