### PR TITLE
doc: Add note on password in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@
         ```yaml
         server: mqtt://localhost:1883
         user: my_user
-        password: my_password
+        password: "my_password"
         ```
+        Note: If the `password` includes certain special characters (reserved by yaml specification), the enclosing quotes are required. So it is recommended to always quote it when in doubt.
     - Fill in the serial details (e.g. port of your USB coordinator). Format can be found [here](https://www.zigbee2mqtt.io/guide/configuration/adapter-settings.html#adapter-settings), but skip the initial `serial:` indent. e.g.: <br>
         ```yaml
         port: /dev/ttyUSB0


### PR DESCRIPTION
When the password has special characters that are reserved by yaml, it must be quoted so it is parsed and extracted correctly. Although it seems obvious, not everyone is aware of this and the way this issue manifests is rather cryptic (says connection refused).

Fix this by quoting the password field and adding a note about it.