### PR TITLE
Use bashio::services for the connection even when base_topic is specified in the config

### DIFF
--- a/common/rootfs/docker-entrypoint.sh
+++ b/common/rootfs/docker-entrypoint.sh
@@ -84,7 +84,7 @@ function export_config() {
 export_config 'mqtt'
 export_config 'serial'
 
-if bashio::config.is_empty 'mqtt' && bashio::var.has_value "$(bashio::services 'mqtt')"; then
+if (bashio::config.is_empty 'mqtt' || ! (bashio::config.has_value 'mqtt.server' || bashio::config.has_value 'mqtt.user' || bashio::config.has_value 'mqtt.password')) && bashio::var.has_value "$(bashio::services 'mqtt')"; then
     if bashio::var.true "$(bashio::services 'mqtt' 'ssl')"; then
         export ZIGBEE2MQTT_CONFIG_MQTT_SERVER="mqtts://$(bashio::services 'mqtt' 'host'):$(bashio::services 'mqtt' 'port')"
     else


### PR DESCRIPTION
*NB*: MARKED AS DRAFT BECAUSE THIS IS NOT TESTED.  I'm opening the PR to see what people think of the idea in the meantime.

When overriding the `base_topic` you end up having to configure the server too, which is a bit annoying.  This comes up when running multiple instances of z2m in hassio.  The change here makes it so that you can specify `mqtt` config keys and still use the bashio services to get server access.  Unless you specify `mqtt.server`, `mqtt.user` or `mqtt.password`.