### PR TITLE
fix: add base_topic to config.json schema

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -60,7 +60,8 @@
       "key": "str?",
       "cert": "str?",
       "user": "str?",
-      "password": "str?"
+      "password": "str?",
+      "base_topic": "str?"
     },
     "serial": {
       "port": "str?",


### PR DESCRIPTION
Make `mqtt.base_topic` editable from the addon page

closes #611 