### PR TITLE
Update build.yaml to support HAOS 13.2

### DIFF
--- a/common/build.yaml
+++ b/common/build.yaml
@@ -1,6 +1,7 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.20
   amd64: ghcr.io/home-assistant/amd64-base:3.20
-  armhf: ghcr.io/home-assistant/armhf-base:3.20
-  armv7: ghcr.io/home-assistant/armv7-base:3.20
   i386: ghcr.io/home-assistant/i386-base:3.20
+  # See https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pull/652#issuecomment-2448119395 why 3.18 is used
+  armhf: ghcr.io/home-assistant/armhf-base:3.18
+  armv7: ghcr.io/home-assistant/armv7-base:3.18

--- a/common/build.yaml
+++ b/common/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
-  amd64: ghcr.io/home-assistant/amd64-base:3.18
-  armhf: ghcr.io/home-assistant/armhf-base:3.18
-  armv7: ghcr.io/home-assistant/armv7-base:3.18
-  i386: ghcr.io/home-assistant/i386-base:3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
+  armhf: ghcr.io/home-assistant/armhf-base:3.20
+  armv7: ghcr.io/home-assistant/armv7-base:3.20
+  i386: ghcr.io/home-assistant/i386-base:3.20


### PR DESCRIPTION
As stated in #651 the Addon is no longer working on the Raspberry Pi with HA OS 13.2.
The problem is the `ghcr.io/home-assistant/aarch64-base:3.18` image with throws Segmentation faults everywhere, Version 3.20 works fine (Only tested on Raspberry Pi 4 aarch64 but I'm pretty sure the updated image wouldn't break anything else)