### PR TITLE
Add a list of breaking versions to prevent auto-updates

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -3,6 +3,9 @@
   "version": "2.0.0-1",
   "slug": "zigbee2mqtt",
   "description": "Use your ZigBee devices without the vendor's bridge or gateway",
+  "breaking_versions": [
+    "2.0.0-1",
+  ],
   "uart": true,
   "udev": true,
   "url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/tree/master/zigbee2mqtt",


### PR DESCRIPTION
Add a list of breaking versions to prevent auto-updates. The functionality was apparently added in [February 2024](https://community.home-assistant.io/t/raspberry-pi-5-support-and-more-in-home-assistant-os-release-12-supervisor-update/696045/15) (or at least the documentation was).

https://developers.home-assistant.io/docs/add-ons/configuration#optional-configuration-options

<img width="852" alt="image" src="https://github.com/user-attachments/assets/2a028d57-45ab-47dc-b453-4f31fe4e69b6" />

I'm not sure if the existing version can just be republished, but if possible, that would probably be the easiest way (as opposed to creating a new `2.0.0-2` version and adding both to `breaking_versions`).