### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@
    - If this takes too long (e.g. 2 minutes +) check the **Log** tab to see what went wrong.
    - In case the add-on fails to start with the following error: `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to fill in the `serial` section (which we skipped in step 5). Format can be found [here](https://www.zigbee2mqtt.io/guide/configuration/adapter-settings.html#adapter-settings), but skip the initial `serial:` indent. e.g.: <br>
      ```yaml
-     port: /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00
      adapter: zstack
+     port: /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00
      ```
      If you don't know the port and you have just one USB device connected to your machine try `/dev/ttyUSB0` or `/dev/ttyAMA0`. Else use the [Home Assistant CLI](https://www.home-assistant.io/common-tasks/os#home-assistant-via-the-command-line) and execute `ha hardware info` to find out.
 


### PR DESCRIPTION
Add the `adapter:` line before the `port:` definition, as it seems many people indent the `adapter:` definition incorrectly. Most likely when they edit the settings, the editor auto-indents incorrectly, to a folded `port:` definition, which misaligns the `adapter:` setting, e.g.:
```
serial:
    port: >-
        /dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_2646e5732827ee11bd268ac1f49e3369-if00-port0
        adapter: zstack
```
Putting the `adapter:` definition at the start, the auto-indenting will not occur (hopefully).
Grt,