### PR TITLE
fix: Frontend config being overriden by env var

### DIFF
--- a/common/rootfs/docker-entrypoint.sh
+++ b/common/rootfs/docker-entrypoint.sh
@@ -55,7 +55,8 @@ if bashio::config.has_value 'watchdog'; then
 fi
 
 export NODE_PATH=/app/node_modules
-export ZIGBEE2MQTT_CONFIG_FRONTEND='{"enabled":true,"port": 8099}'
+export ZIGBEE2MQTT_CONFIG_FRONTEND_ENABLED='true'
+export ZIGBEE2MQTT_CONFIG_FRONTEND_PORT='8099'
 export ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED='true'
 export Z2M_ONBOARD_URL='http://0.0.0.0:8099'
 


### PR DESCRIPTION
Fixes issue setting frontend configuration variables when running from HA addon.

https://github.com/Koenkk/zigbee2mqtt/issues/26987