### PR TITLE
Get timezone from the supervisor and use it in Z2M container

### DIFF
--- a/common/rootfs/docker-entrypoint.sh
+++ b/common/rootfs/docker-entrypoint.sh
@@ -87,6 +87,8 @@ function export_config() {
 export_config 'mqtt'
 export_config 'serial'
 
+export TZ="$(bashio::supervisor.timezone)"
+
 if (bashio::config.is_empty 'mqtt' || ! (bashio::config.has_value 'mqtt.server' || bashio::config.has_value 'mqtt.user' || bashio::config.has_value 'mqtt.password')) && bashio::var.has_value "$(bashio::services 'mqtt')"; then
     if bashio::var.true "$(bashio::services 'mqtt' 'ssl')"; then
         export ZIGBEE2MQTT_CONFIG_MQTT_SERVER="mqtts://$(bashio::services 'mqtt' 'host'):$(bashio::services 'mqtt' 'port')"


### PR DESCRIPTION
This PR gets the timezone from HA's supervisor and uses it for Z2M, allowing the correct time to be set on Zigbee accessories.

Fixes https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/issues/298.