### PR TITLE
Add permission to access the Supervisor API

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -10,6 +10,7 @@
   "services": [
     "mqtt:need"
   ],
+  "hassio_api": true,
   "arch": [
     "aarch64",
     "amd64",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -13,6 +13,7 @@
   "services": [
     "mqtt:need"
   ],
+  "hassio_api": true,
   "arch": [
     "aarch64",
     "amd64",


### PR DESCRIPTION
Fix bug introduced in https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pull/770 where we try to access the supervisor API without the required permission.

This edits the add-on's manifest to give it access to the supervisor API so it can fetch the timezone properly.