### PR TITLE
feat: enforce no proxy caching

### DIFF
--- a/zigbee2mqtt-proxy/config.json
+++ b/zigbee2mqtt-proxy/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Zigbee2MQTT Proxy",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "slug": "zigbee2mqtt_proxy",
     "description": "Proxy for externally running Zigbee2MQTT",
     "url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/tree/master/zigbee2mqtt-proxy",

--- a/zigbee2mqtt-proxy/entrypoint.sh
+++ b/zigbee2mqtt-proxy/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 tempio -conf /data/options.json -template /nginx.conf.gtpl -out /tmp/nginx.conf
-nginx -T -c /tmp/nginx.conf
+nginx -t -c /tmp/nginx.conf
 
 exec nginx -c /tmp/nginx.conf

--- a/zigbee2mqtt-proxy/nginx.conf.gtpl
+++ b/zigbee2mqtt-proxy/nginx.conf.gtpl
@@ -61,6 +61,13 @@ http {
             proxy_send_timeout          86400s;
             proxy_max_temp_file_size    0;
 
+            proxy_no_cache     1;
+            proxy_cache_bypass 1;
+
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires 0;
+
             proxy_set_header Accept-Encoding "";
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
This should ensure nothing is ever cached by the proxy (should be disabled by default, but something seems to be causing [troubles](https://github.com/Nerivec/zigbee2mqtt-windfront/issues/101), so, just in case, this is explicit on all fronts...).
Also fixes the [test param of nginx cmd](https://wiki.alpinelinux.org/wiki/Nginx#Test_configuration).

@Koenkk a rebuild of the proxy addon should be triggered regularly (current was 4m ago), and a version bump should occur at least when the base image version is bumped.
Also, something seems to be messing with the [container manifest](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pkgs/container/zigbee2mqtt-proxy-amd64/375227408?tag=latest) (lack of version bumping, not updating metadata?):
```
    "io.hass.base.image": "alpine:3.16",
    "org.opencontainers.image.source": "https://github.com/home-assistant/docker-base",
    "io.hass.base.arch": "amd64",
    "io.hass.version": "0.2.0",
    "org.opencontainers.image.created": "2022-11-13 14:06:40+00:00",
    "org.opencontainers.image.version": "0.2.0",
    "io.hass.name": "Zigbee2MQTT Proxy",
    "io.hass.arch": "amd64",
    "io.hass.base.version": "2022.09.0",
    "io.hass.base.name": "alpine",
    "io.hass.description": "Proxy for externally running Zigbee2MQTT",
    "io.hass.url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/tree/master/zigbee2mqtt-proxy",
    "io.hass.type": "addon"
```