### PR TITLE
Add healthcheck in Dockerfile

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -4,7 +4,9 @@ FROM $BUILD_FROM as base
 ENV LANG C.UTF-8
 ARG BUILD_VERSION
 
-RUN apk add --no-cache socat tini nodejs eudev
+RUN apk add --no-cache socat tini nodejs eudev && \
+    # Validation to confirm that curl is installed in the base image.
+    curl --version || (echo "curl missing" && exit 1)
 
 # Dependencies and build
 FROM base as dependencies_and_build
@@ -49,10 +51,7 @@ COPY --from=dependencies_and_build /app/package.json /app/LICENSE /app/index.js 
 
 ENV NODE_ENV production
 
-# Validation to confirm that CURL is installed in the final image.
-RUN curl --version || (echo "curl missing" && exit 1)
-
 HEALTHCHECK --interval=1m --timeout=3s \
-  CMD curl -f http://localhost:8099/ || exit 1
-  
+  CMD curl -f http://localhost:8099/
+
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
Part of: https://github.com/Koenkk/zigbee2mqtt/issues/28893

This adds a basic health check.
A more complete check (including whether the HTTP server is connected to MQTT) would be useful, but that’ll require server-side changes — so it’s better left for a follow-up.
Even so, this should already improve web server stability, since the Supervisor won’t route traffic to the app until it can accept HTTP requests.