### PR TITLE
fix: Remove i386, armhf and armv7

### DIFF
--- a/common/build.yaml
+++ b/common/build.yaml
@@ -1,6 +1,3 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.22
   amd64: ghcr.io/home-assistant/amd64-base:3.22
-  i386: ghcr.io/home-assistant/i386-base:3.22
-  armhf: ghcr.io/home-assistant/armhf-base:3.22
-  armv7: ghcr.io/home-assistant/armv7-base:3.22

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -13,10 +13,7 @@
   "hassio_api": true,
   "arch": [
     "aarch64",
-    "amd64",
-    "armhf",
-    "armv7",
-    "i386"
+    "amd64"
   ],
   "boot": "auto",
   "init": false,

--- a/zigbee2mqtt-proxy/config.json
+++ b/zigbee2mqtt-proxy/config.json
@@ -6,10 +6,7 @@
     "url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/tree/master/zigbee2mqtt-proxy",
     "arch": [
       "aarch64",
-      "amd64",
-      "armhf",
-      "armv7",
-      "i386"
+      "amd64"
     ],
     "boot": "auto",
     "init": true,

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -16,10 +16,7 @@
   "hassio_api": true,
   "arch": [
     "aarch64",
-    "amd64",
-    "armhf",
-    "armv7",
-    "i386"
+    "amd64"
   ],
   "boot": "auto",
   "init": false,


### PR DESCRIPTION
Remove support as HA removed support for these architectures ([builds are failing due to this](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/actions/runs/19595519350/job/56119643297)). More [info](https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems/)