### PR TITLE
Rename add-on to app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Setting up
-1. Git clone this project into your add-ons folder
+1. Git clone this project into your apps folder
 2. Remove the `image` key from `zigbee2mqtt-edge/config.json` to enable local builds.
 3. Add back `"image": "zigbee2mqtt/zigbee2mqtt-edge-{arch}"` to `zigbee2mqtt-edge/config.json` after you're done.
 
@@ -16,11 +16,11 @@ Release title: v1.25.2-1
 
 # Developing against the Home Assistant container
 
-When you want to check the impact of developing work, e.g. adjusting devices in [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters), you need access to the add-on container in Home Assistant. Here's how:
+When you want to check the impact of developing work, e.g. adjusting devices in [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters), you need access to the app container in Home Assistant. Here's how:
 
-🚨 Following these directions will make your Home Assistant system more prone to misconfiguration (by yourself) to the extent of rendering it completely useless, so only touch what you're confident to and "know what you do". 
+🚨 Following these directions will make your Home Assistant system more prone to misconfiguration (by yourself) to the extent of rendering it completely useless, so only touch what you're confident to and "know what you do".
 
-1. install the [Portainer add-on](https://github.com/hassio-addons/addon-portainer) from the Add-on store
+1. install the [Portainer app](https://github.com/hassio-addons/addon-portainer) from the App store
 2. Make sure to disable its `Protection mode`:
   ![image](https://user-images.githubusercontent.com/1125168/118788032-aa316800-b893-11eb-8567-f2122159f64c.png)
 3. Start Portainer and `Open Web UI`
@@ -28,8 +28,8 @@ When you want to check the impact of developing work, e.g. adjusting devices in 
     1. head to `Settings` > section *Hidden Containers* and remove `io.hass.type`: `addon`
     2. go to `Containers`, `addon_[…]_zigbee2mqtt`, `Console`, `Connect`
 5. ℹ️ the location of zigbee-herdsman-converters for example is `/app/node_modules/zigbee-herdsman-converters`
-6. make your adjustments by copying or `vi`'ing 
-7. Still in portainer, go back to the add-on's container and `Restart`
+6. make your adjustments by copying or `vi`'ing
+7. Still in portainer, go back to the app's container and `Restart`
 
 ## Alternative (without portainer)
 
@@ -40,7 +40,7 @@ When you want to check the impact of developing work, e.g. adjusting devices in 
 5. execute `docker cp` (eg. `docker cp <the location of your build>/. <container_name>:/app/node_modules/zigbee-herdsman-converters`)
 6. execute `docker restart <container name>`
 
-⚠️ Note that restarting the add-on via Supervisor or further down the stack will revert the file changes.
+⚠️ Note that restarting the app via Supervisor or further down the stack will revert the file changes.
 
 After work is done, don't forget to clean up and reintroduce the safety measures:
 1. re-add the filter `io.hass.type`: `addon` for *Hidden Containers*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
             <img src="https://img.shields.io/discord/556563650429583360.svg">
         </a>
     </div>
-    <h1>Official Zigbee2MQTT Home Assistant add-on</h1>
+    <h1>Official Zigbee2MQTT Home Assistant app</h1>
 </div>
 
 > [!CAUTION]
@@ -26,14 +26,14 @@
 
 ## Installation
 
-1. If you don't have an MQTT broker yet; in Home Assistant go to **[Settings → Add-ons → Add-on store](https://my.home-assistant.io/redirect/supervisor_store/)** and install the **[Mosquitto broker](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_mosquitto)** add-on, then start it.
-1. Go back to the **Add-on store**, click **⋮ → Repositories**, fill in</br> `https://github.com/zigbee2mqtt/hassio-zigbee2mqtt` and click **Add → Close** or click the **Add repository** button below, click **Add → Close** (You might need to enter the **internal IP address** of your Home Assistant instance first).  
-   [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fzigbee2mqtt%2Fhassio-zigbee2mqtt)
-1. The repository includes two add-ons:
+1. If you don't have an MQTT broker yet; in Home Assistant go to **[Settings → Apps → App store](https://my.home-assistant.io/redirect/supervisor_store/)** and install the **[Mosquitto broker](https://my.home-assistant.io/redirect/supervisor_addon/?addon=core_mosquitto)** app, then start it.
+1. Go back to the **App store**, click **⋮ → Repositories**, fill in</br> `https://github.com/zigbee2mqtt/hassio-zigbee2mqtt` and click **Add → Close** or click the **Add repository** button below, click **Add → Close** (You might need to enter the **internal IP address** of your Home Assistant instance first).
+   [![Open your Home Assistant instance and show the add app repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fzigbee2mqtt%2Fhassio-zigbee2mqtt)
+1. The repository includes two apps:
    - **Zigbee2MQTT** is the stable release that tracks the released versions of Zigbee2MQTT. (**recommended for most users**)
    - **Zigbee2MQTT Edge** tracks the `dev` branch of Zigbee2MQTT such that you can install the edge version if there are features or fixes in the Zigbee2MQTT dev branch that are not yet released.
-1. Click on the add-on and press **Install** and wait till the add-on is installed.
-1. Start the add-on by going to **Info** and click **Start**
+1. Click on the app and press **Install** and wait till the app is installed.
+1. Start the app by going to **Info** and click **Start**
 1. Wait a few seconds and press **OPEN WEB UI**, you will now see the onboarding page. More information about the onboarding can be found [here](https://www.zigbee2mqtt.io/guide/getting-started/#onboarding).
 1. Fill in the desired settings, for most setups changing the following is enough:
    - Select your adapter under _Found Devices_, this will configure the _Coordinator/Adapter Port/Path_ and _Coordinator/Adapter Type/Stack/Driver_.
@@ -41,7 +41,7 @@
 1. Press **Submit**, Zigbee2MQTT will now start, wait a few seconds and refresh the page. You should now see the Zigbee2MQTT frontend.
    - If it shows `502: Bad Gateway` wait a bit more and refresh the page.
    - If this takes too long (e.g. 2 minutes +) check the **Log** tab to see what went wrong.
-   - In case the add-on fails to start with the following error: `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to fill in the `serial` section. Format can be found [here](https://www.zigbee2mqtt.io/guide/configuration/adapter-settings.html#adapter-settings), but skip the initial `serial:` indent. e.g.: <br>
+   - In case the app fails to start with the following error: `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to fill in the `serial` section. Format can be found [here](https://www.zigbee2mqtt.io/guide/configuration/adapter-settings.html#adapter-settings), but skip the initial `serial:` indent. e.g.: <br>
      ```yaml
      adapter: zstack
      port: /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00
@@ -53,15 +53,15 @@ For more information see [the documentation](https://github.com/zigbee2mqtt/hass
 ## Restoring data from a standalone installation
 
 1. Ensure that both environments are running the same version
-1. Ensure you can [SSH to your Home Assistant OS](https://community.home-assistant.io/t/howto-how-to-access-the-home-assistant-os-host-itself-over-ssh/263352) (NOT to the SSH Add-on)
+1. Ensure you can [SSH to your Home Assistant OS](https://community.home-assistant.io/t/howto-how-to-access-the-home-assistant-os-host-itself-over-ssh/263352) (NOT to the SSH App)
 1. Backup your standalone environment `data` folder (possibly leaving out the `logs/` folder)
-1. Start the Zigbee2MQTT HA add-on with a non-existing `tty` device, to create the `data` folder
+1. Start the Zigbee2MQTT HA app with a non-existing `tty` device, to create the `data` folder
 1. Restore your `data` folder contents into `/mnt/data/supervisor/homeassistant/zigbee2mqtt`, e.g. via `scp -O -P 22222 -i  PATHTOUSEDSSHKEY ./data/* root@hass:/mnt/data/supervisor/homeassistant/zigbee2mqtt/`
-1. Configure your serial port and MQTT settings using the HA add-on configuration UI
+1. Configure your serial port and MQTT settings using the HA app configuration UI
 1. Edit the `/usr/share/hassio/homeassistant/zigbee2mqtt/configuration.yaml` file:
    - Ensure that the serial port section matches the one configured with the UI
    - Remove any irrelevant sections from the config (e.g. `mqtt` (if not needed), `advanced/log_syslog`, `frontend`)
-1. Start the add-on
+1. Start the app
 
 ## Changelog
 
@@ -71,13 +71,13 @@ All notable changes to this project will be documented in the [CHANGELOG.md](zig
 
 Version for releases is based on [Zigbee2MQTT](https://github.com/Koenkk/zigbee2mqtt) format: `X.Y.Z`.
 
-Any changes on the add-on that do not require a new version of Zigbee2MQTT will use the format: `X.Y.Z-A` where `X.Y.Z` is fixed on the Zigbee2MQTT release version and `A` is related to the add-on.
+Any changes on the app that do not require a new version of Zigbee2MQTT will use the format: `X.Y.Z-A` where `X.Y.Z` is fixed on the Zigbee2MQTT release version and `A` is related to the app.
 
 Edge version will not maintain a CHANGELOG and doesn't have a version.
 
 ## Issues
 
-If you find any issues with the add-on, please check the [issue tracker](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/issues) for similar issues before creating one. If your issue is regarding specific devices or, more generally, an issue that arises after Zigbee2MQTT has successfully started, it should likely be reported in the [Zigbee2MQTT issue tracker](https://github.com/Koenkk/zigbee2mqtt/issues).
+If you find any issues with the app, please check the [issue tracker](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/issues) for similar issues before creating one. If your issue is regarding specific devices or, more generally, an issue that arises after Zigbee2MQTT has successfully started, it should likely be reported in the [Zigbee2MQTT issue tracker](https://github.com/Koenkk/zigbee2mqtt/issues).
 
 Feel free to create a PR for fixes and enhancements.
 
@@ -86,7 +86,7 @@ Feel free to create a PR for fixes and enhancements.
 If you're submitting a PR and wish to test it locally:
 
 - Gain root access to your Home Assistant installation
-- In the Add-on Settings, Ensure "Watchdog" is turned off so the container isn't automatically restarted when it's stopped via the CLI
+- In the App Settings, Ensure "Watchdog" is turned off so the container isn't automatically restarted when it's stopped via the CLI
 
 ![image](https://user-images.githubusercontent.com/1923186/198087147-7ab2ba1e-1a68-41b8-9a84-76b25b329786.png)
 

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Home Assistant Add-on: Zigbee2MQTT",
+  "name": "Home Assistant App: Zigbee2MQTT",
   "url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt",
   "maintainer": "Koen Kanters <koenkanters94@gmail.com>"
 }

--- a/zigbee2mqtt-edge/README.md
+++ b/zigbee2mqtt-edge/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Zigbee2MQTT Edge
+# Home Assistant App: Zigbee2MQTT Edge
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/zigbee2mqtt/zigbee2mqtt-edge-amd64.svg?style=flat-square&logo=docker)](https://cloud.docker.com/u/zigbee2mqtt/repository/docker/dwelch2101/zigbee2mqtt-edge-amd64)
 
@@ -10,14 +10,14 @@ It bridges events and allows you to control your Zigbee devices via MQTT. In thi
 
 See Documentation tab for more details.
 
-### Updating the Edge add-on
-To update the `edge` version of the add-on, you will need to uninstall and re-install the add-on.
+### Updating the Edge app
+To update the `edge` version of the app, you will need to uninstall and re-install the app.
 
 ⚠️ Make sure to backup your config as the procedure will not save this for you.
 
 **Steps**
-1. Backup config from: **Settings → Add-ons → Zigbee2MQTT Edge → Configuration → ⋮ → Edit in YAML**, copy the **Options** somewhere safe
-1. Uninstall: **Settings → Add-ons → Zigbee2MQTT Edge → Uninstall**
-1. Refresh repo: **Settings → Add-ons → Add-ons store → ⋮ → Check for updates**
-1. Install: **Settings → Add-ons → Add-ons store → Zigbee2MQTT Edge → Install**
-1. Restore config to: **Settings → Add-ons → Zigbee2MQTT Edge → Configuration → ⋮ → Edit in YAML**, paste your config from step 1.
+1. Backup config from: **Settings → Apps → Zigbee2MQTT Edge → Configuration → ⋮ → Edit in YAML**, copy the **Options** somewhere safe
+1. Uninstall: **Settings → Apps → Zigbee2MQTT Edge → Uninstall**
+1. Refresh repo: **Settings → Apps → Apps store → ⋮ → Check for updates**
+1. Install: **Settings → Apps → Apps store → Zigbee2MQTT Edge → Install**
+1. Restore config to: **Settings → Apps → Zigbee2MQTT Edge → Configuration → ⋮ → Edit in YAML**, paste your config from step 1.

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -2,7 +2,7 @@
   "name": "Zigbee2MQTT Edge",
   "version": "edge",
   "slug": "zigbee2mqtt_edge",
-  "description": "Development build of the Zigbee2MQTT add-on",
+  "description": "Development build of the Zigbee2MQTT app",
   "uart": true,
   "udev": true,
   "url": "https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/tree/master/zigbee2mqtt-edge",

--- a/zigbee2mqtt-proxy/README.md
+++ b/zigbee2mqtt-proxy/README.md
@@ -1,11 +1,11 @@
-# Home Assistant Add-on: Zigbee2MQTT Proxy
+# Home Assistant App: Zigbee2MQTT Proxy
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/zigbee2mqtt/zigbee2mqtt-proxy-amd64.svg?style=flat-square&logo=docker)](https://cloud.docker.com/u/zigbee2mqtt/repository/docker/dwelch2101/zigbee2mqtt-proxy-amd64)
 
-⚠️ This add-on does not contain Zigbee2MQTT ⚠️
+⚠️ This app does not contain Zigbee2MQTT ⚠️
 
-This add-on acts as a proxy to an external running Zigbee2MQTT instance. 
-The sole purpose of this add-on is to add a Zigbee2MQTT icon to the sidebar of Home Assistant which will open the frontend of an external running Zigbee2MQTT instance.
+This app acts as a proxy to an external running Zigbee2MQTT instance.
+The sole purpose of this app is to add a Zigbee2MQTT icon to the sidebar of Home Assistant which will open the frontend of an external running Zigbee2MQTT instance.
 
 ## Options
 

--- a/zigbee2mqtt/DOCS.md
+++ b/zigbee2mqtt/DOCS.md
@@ -1,29 +1,29 @@
 # Pairing
 
-By default the add-on has `permit_join` set to `false`. To allow devices to join you need to activate this after the add-on has started. You can now use the [built-in frontend](https://www.zigbee2mqtt.io/information/frontend.html) to achieve this. For details on how to enable the built-in frontent see the next section.
+By default the app has `permit_join` set to `false`. To allow devices to join you need to activate this after the app has started. You can now use the [built-in frontend](https://www.zigbee2mqtt.io/information/frontend.html) to achieve this. For details on how to enable the built-in frontent see the next section.
 
 # Enabling the built-in frontend
 
-Enable `ingress` to have the frontend available in your UI: **Settings → Add-ons → Zigbee2MQTT → Show in sidebar**. You can find more details about the feature on the [Zigbee2MQTT documentation](https://www.zigbee2mqtt.io/information/frontend.html).
+Enable `ingress` to have the frontend available in your UI: **Settings → Apps → Zigbee2MQTT → Show in sidebar**. You can find more details about the feature on the [Zigbee2MQTT documentation](https://www.zigbee2mqtt.io/information/frontend.html).
 
 # Configuration
 
 ## Onboarding
 
-[Onboarding](https://www.zigbee2mqtt.io/guide/getting-started/#onboarding) allows you to setup Zigbee2MQTT without having to manually enter the details in the add-on configuration page. When starting the add-on with a brand new install (no configuration present), the frontend will show a quick setup page, allowing you to select various settings for Zigbee2MQTT to be able to start.
+[Onboarding](https://www.zigbee2mqtt.io/guide/getting-started/#onboarding) allows you to setup Zigbee2MQTT without having to manually enter the details in the app configuration page. When starting the app with a brand new install (no configuration present), the frontend will show a quick setup page, allowing you to select various settings for Zigbee2MQTT to be able to start.
 
 > [!NOTE]
 > Successful detection of adapters, to select from, may vary based on your setup/network. You may have to enter these [details manually](https://www.zigbee2mqtt.io/guide/configuration/adapter-settings.html#basic-configuration) on the page instead.
 
 > [!TIP]
-> You can force the onboarding to re-run (e.g. changing adapter) using the toggle available in the add-on configuration page (visible after checking `Show unused optional configuration options`). This will force onboarding to run even after you have successfully configured it for the first time. Make sure to disable it once done.
+> You can force the onboarding to re-run (e.g. changing adapter) using the toggle available in the app configuration page (visible after checking `Show unused optional configuration options`). This will force onboarding to run even after you have successfully configured it for the first time. Make sure to disable it once done.
 
 ## Manual
 
-Configuration required to startup Zigbee2MQTT is available from the add-on configuration. The rest of the options can be configured via the Zigbee2MQTT frontend.
+Configuration required to startup Zigbee2MQTT is available from the app configuration. The rest of the options can be configured via the Zigbee2MQTT frontend.
 
 > [!CAUTION]
-> Settings configured through the add-on configuration page will take precedence over settings in the `configuration.yaml` page (e.g. you set `rtscts: false` in add-on configuration page and `rtscts: true` in `configuration.yaml`, `rtscts: false` will be used). _If you want to control the entire configuration through YAML, remove them from the add-on configuration page._
+> Settings configured through the app configuration page will take precedence over settings in the `configuration.yaml` page (e.g. you set `rtscts: false` in app configuration page and `rtscts: true` in `configuration.yaml`, `rtscts: false` will be used). _If you want to control the entire configuration through YAML, remove them from the app configuration page._
 
 #### Examples for each configuration section
 
@@ -49,12 +49,12 @@ Configuration required to startup Zigbee2MQTT is available from the add-on confi
 
 # Configuration backup
 
-The add-on will create a backup of your configuration.yml within your data path: `$DATA_PATH/configuration.yaml.bk`. When upgrading, you should use this to fill in the relevant values into your new config, particularly the network key, to avoid breaking your network and having to re-pair all of your devices.
-The backup of your configuration is created on add-on startup if no previous backup was found.
+The app will create a backup of your configuration.yml within your data path: `$DATA_PATH/configuration.yaml.bk`. When upgrading, you should use this to fill in the relevant values into your new config, particularly the network key, to avoid breaking your network and having to re-pair all of your devices.
+The backup of your configuration is created on app startup if no previous backup was found.
 
 # Enabling the watchdog
 
-To automatically restart Zigbee2MQTT in case of a soft failure (like "adapter disconnected"), the watchdog can be used. It can be enabled by adding the following to the add-on configuration:
+To automatically restart Zigbee2MQTT in case of a soft failure (like "adapter disconnected"), the watchdog can be used. It can be enabled by adding the following to the app configuration:
 
 ```yaml
 watchdog: default
@@ -68,7 +68,7 @@ If you are interested in adding support for new devices to Zigbee2MQTT see [How 
 
 # Notes
 
-- Depending on your configuration, the MQTT server config may need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Home Assistant's Mosquitto add-on.
+- Depending on your configuration, the MQTT server config may need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Home Assistant's Mosquitto app.
 - To find out which serial ports you have exposed go to **Supervisor → System → Host system → ⋮ → Hardware**
 
 # Socat

--- a/zigbee2mqtt/README.md
+++ b/zigbee2mqtt/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Zigbee2MQTT
+# Home Assistant App: Zigbee2MQTT
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/zigbee2mqtt/zigbee2mqtt-amd64.svg?style=flat-square&logo=docker)](https://cloud.docker.com/u/dwelch2101/repository/docker/zigbee2mqtt/zigbee2mqtt-amd64)
 


### PR DESCRIPTION
Home Assistant has changed their teminology and renamed add-on to app.
- see Architecture discussion: Rename “Add-ons” to “Apps” https://github.com/home-assistant/architecture/discussions/1287
- [Release notes 2026.2: add-ons are now called app](https://www.home-assistant.io/blog/2026/02/04/release-20262/#add-ons-are-now-called-apps)