### PR TITLE
fix: Fix aarch64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         cp common/build.yaml ${{ matrix.addon }}
 
     - name: Build
-      uses: home-assistant/builder@cbf7a23cbac618ce32147f0fe3854d4d1388e289
+      uses: home-assistant/builder@2025.11.0
       # Note: if running without `--test`, image is pushed to docker.io
       with:
         args: |


### PR DESCRIPTION
I have the feeling that https://github.com/home-assistant/builder/pull/267 broke the aarc64 builds, lock the builder version to fix it.